### PR TITLE
Enable “Create Page”

### DIFF
--- a/src/App.ts
+++ b/src/App.ts
@@ -108,7 +108,7 @@ export default class App {
     if (size === 'default') {
       // retrieve existing options
       const lastUsedOptions: {
-        action: 'duplicate' | 'replace',
+        action: 'duplicate' | 'replace' | 'new-page',
         translateLocked: boolean,
         languages: Array<string>,
       } = await figma.clientStorage.getAsync(DATA_KEYS.options);
@@ -157,7 +157,7 @@ export default class App {
   async runTranslate(
     options: {
       languages: Array<string>,
-      action: 'duplicate' | 'replace',
+      action: 'duplicate' | 'replace' | 'new-page',
       translateLocked: boolean,
     },
     savePrefs: boolean,

--- a/src/App.ts
+++ b/src/App.ts
@@ -219,8 +219,17 @@ export default class App {
       figma.clientStorage.setAsync(DATA_KEYS.options, options);
     }
 
+    // if action is `new-page`, need to create a new page first
+    let newPage = null;
+    if (textNodes.length > 0 && action === 'new-page') {
+      newPage = figma.createPage();
+    }
+
     // if action is `duplicate`, need to duplicate the layers first
-    if (textNodes.length > 0 && action === 'duplicate') {
+    if (
+      textNodes.length > 0
+      && (action === 'duplicate' || action === 'new-page')
+    ) {
       consolidatedSelection = [];
 
       selection.forEach((node) => {
@@ -228,7 +237,7 @@ export default class App {
         const painter = new Painter({ for: node, in: page });
 
         // duplicate the layer
-        const newNodeResult = painter.duplicate();
+        const newNodeResult = painter.duplicate(newPage);
         if (newNodeResult.status === 'success') {
           const newNode = newNodeResult.node;
           consolidatedSelection.push(newNode);

--- a/src/App.ts
+++ b/src/App.ts
@@ -33,14 +33,16 @@ const assemble = (context: any = null) => {
 
 /**
  * @description Retrieves all of the typefaces (`FontName`) from a selection of text nodes
- * and returns them as a unique array (no repeats).
+ * and returns them as a unique array (without repeats).
  *
  * @kind function
  * @name readTypefaces
  *
+ * @param {Array} textNodes Array of the text next (`TextNode`) to retrieve typefaces from.
+ *
  * @returns {Array} Returns an array of unique `FontName` entries (no repeats).
  */
-const readTypefaces = (textNodes) => {
+const readTypefaces = (textNodes: Array<TextNode>) => {
   const uniqueTypefaces: Array<FontName> = [];
 
   // take the typeface and, if new/unique, add it to the `uniqueTypefaces` array
@@ -51,6 +53,7 @@ const readTypefaces = (textNodes) => {
         && foundItem.style === typeface.style),
     );
 
+    // typeface is not present; add it to the array
     if (itemIndex < 0) {
       uniqueTypefaces.push(typeface);
     }

--- a/src/App.ts
+++ b/src/App.ts
@@ -244,6 +244,11 @@ export default class App {
         }
       });
 
+      if (newPage && action === 'new-page') {
+        figma.currentPage = newPage;
+        figma.currentPage.selection = newPage.children;
+      }
+
       // reset and retrieve selection of text nodes
       textNodes = new Crawler({ for: consolidatedSelection }).text(translateLocked);
     }

--- a/src/App.ts
+++ b/src/App.ts
@@ -215,18 +215,29 @@ export default class App {
       messenger.log('End manipulating text');
     };
 
-    /** WIP
-     * @description Does a thing.
+    /**
+     * @description Resets the plugin GUI back to the original state or closes it entirely,
+     * terminating the plugin.
      *
      * @kind function
-     * @name close
+     * @name closeOrReset
      *
-     * @returns {null} Shows a Toast in the UI if nothing is selected.
+     * @returns {null}
      */
-    const close = () => {
+    const closeOrReset = () => {
       if (this.shouldTerminate) {
-        this.terminatePlugin();
+        return this.terminatePlugin();
       }
+
+      // reset the working state
+      const message: {
+        action: string,
+      } = {
+        action: 'resetState',
+      };
+      figma.ui.postMessage(message);
+
+      return null;
     };
 
     // begin main thread of action ------------------------------------------------------
@@ -292,7 +303,7 @@ export default class App {
         manipulateText(textNodes);
       }
 
-      return close();
+      return closeOrReset();
     }
 
     // otherwise display appropriate error messages
@@ -301,6 +312,6 @@ export default class App {
       : '❌ You need to select at least one unlocked text layer';
     messenger.toast(toastErrorMessage);
     messenger.log('No text nodes were selected/found');
-    return close();
+    return closeOrReset();
   }
 }

--- a/src/Crawler.ts
+++ b/src/Crawler.ts
@@ -110,13 +110,13 @@ export default class Crawler {
     return flatSelection;
   }
 
-  /** WIP
+  /**
    * @description Looks into the selection array for any groups and pulls out
    * individual TextNode layers.
    *
    * @kind function
    * @name text
-   * @param {bool} includeLocked Determines whether or not locked layers are included
+   * @param {boolean} includeLocked Determines whether or not locked layers are included
    * in the selection.
    *
    * @returns {Array} All TextNode items in an array.
@@ -128,7 +128,7 @@ export default class Crawler {
     // filter and retain immediate text nodes
     let textNodes: Array<TextNode> = layers.filter((node: SceneNode) => node.type === 'TEXT');
 
-    // iterate through components
+    // iterate through components to find additional text nodes
     const componentNodes: Array<ComponentNode | InstanceNode> = layers.filter((node: SceneNode) => ((node.type === 'COMPONENT' || node.type === 'INSTANCE') && node.visible));
     if (componentNodes) {
       componentNodes.forEach((componentNode: ComponentNode | InstanceNode) => {

--- a/src/GUI.ts
+++ b/src/GUI.ts
@@ -23,6 +23,43 @@ const sendLoadedMsg = (): void => {
 };
 
 /**
+ * @description Manipulates the webview DOM to set the visual button state.
+ *
+ * @kind function
+ * @name setButtonState
+ *
+ * @param {('ready' | 'working')} action String representing the state to show.
+ * @param {Object} button An optional button DOM element.
+ *
+ * @returns {null}
+ */
+const setButtonState = (
+  action: 'ready' | 'working' = 'ready',
+  button?: HTMLButtonElement,
+) => {
+  // define the button
+  let buttonElement: HTMLButtonElement = null;
+  if (!button) {
+    buttonElement = (<HTMLButtonElement> document.getElementById('submit'));
+  } else {
+    buttonElement = button;
+  }
+
+  // update the button
+  if (buttonElement) {
+    if (action === 'working') {
+      buttonElement.innerHTML = 'Working…';
+      buttonElement.classList.add('working');
+    } else {
+      buttonElement.innerHTML = 'Translate';
+      buttonElement.classList.remove('working');
+    }
+  }
+
+  return null;
+};
+
+/**
  * @description Populates the `languages` <select> menu with a list of languages
  * in the constants (LANGUAGES).
  *
@@ -109,12 +146,19 @@ const watchActions = (): void => {
   if (actionsElement) {
     const onClick = (e: MouseEvent) => {
       const target = e.target as HTMLTextAreaElement;
-      const button = target.closest('button');
+      const button: HTMLButtonElement = target.closest('button');
       if (button) {
         // find action by element id
         const action = button.id;
 
-        if (action === 'submit') {
+        if (
+          action === 'submit'
+          && !button.classList.contains('working')
+        ) {
+          // GUI - show we are working
+          setButtonState('working', button);
+
+          // read the form options
           const payload = readOptions();
 
           // bubble action to main
@@ -215,6 +259,9 @@ const watchIncomingMessages = (): void => {
         break;
       case 'setOptions':
         setOptions(pluginMessage.payload);
+        break;
+      case 'resetState':
+        setButtonState('ready');
         break;
       default:
         return null;

--- a/src/GUI.ts
+++ b/src/GUI.ts
@@ -104,14 +104,14 @@ const initLanguages = (): void => {
   return null;
 };
 
-/** WIP
- * @description Compiles the plugin’s options form elements into an object formatted for
- * consumption in the main thread.
+/**
+ * @description Compiles the plugin options form elements in the webview DOM into an object
+ * formatted for consumption in the main thread.
  *
  * @kind function
  * @name readOptions
  *
- * @returns {Object} option Includes an array of languages to translate, the action to take
+ * @returns {Object} options Includes an array of languages to translate, the action to take
  * on the text blocks, and whether or not to ignore locked layers.
  */
 const readOptions = () => {
@@ -180,15 +180,16 @@ const watchActions = (): void => {
 
 /* process Messages from the plugin */
 
-/** WIP
- * @description Compiles the plugin’s options form elements into an object formatted for
- * consumption in the main thread.
+/**
+ * @description Sets the plugin’s form elements in the webview DOM to the correct options.
  *
  * @kind function
  * @name setOptions
  *
- * @returns {Object} option Includes an array of languages to translate, the action to take
+ * @param {Object} options Should include an array of languages to translate, the action to take
  * on the text blocks, and whether or not to ignore locked layers.
+ *
+ * @returns {null}
  */
 const setOptions = (options: {
   action: 'duplicate' | 'replace' | 'new-page',
@@ -228,7 +229,10 @@ const setOptions = (options: {
     translateLockedElement.checked = translateLocked;
   }
 
+  // tell the main thread that the plugin has loaded
   sendLoadedMsg();
+
+  return null;
 };
 
 /**

--- a/src/GUI.ts
+++ b/src/GUI.ts
@@ -147,7 +147,7 @@ const watchActions = (): void => {
  * on the text blocks, and whether or not to ignore locked layers.
  */
 const setOptions = (options: {
-  action: 'duplicate' | 'replace',
+  action: 'duplicate' | 'replace' | 'new-page',
   translateLocked: boolean,
   languages: Array<string>,
 }): void => {

--- a/src/Painter.ts
+++ b/src/Painter.ts
@@ -34,7 +34,7 @@ export default class Painter {
     this.page = page;
   }
 
-  duplicate() {
+  duplicate(newPage?: PageNode) {
     const result: {
       node: SceneNode,
       status: 'error' | 'success',
@@ -59,7 +59,7 @@ export default class Painter {
 
     // create text node + update characters and typeface
     const newNode: SceneNode = this.layer.clone();
-    this.layer.parent.appendChild(newNode);
+    newPage ? newPage.appendChild(newNode) : this.layer.parent.appendChild(newNode);
 
     // force unlock - no one expects new layers to be locked
     newNode.locked = false;

--- a/src/Tools.ts
+++ b/src/Tools.ts
@@ -247,7 +247,7 @@ const findTopFrame = (layer: any) => {
 
   // loop through each parent until we find the outermost FRAME
   if (parent) {
-    while (parent.type !== FRAME_TYPES.main) {
+    while (parent && parent.type !== FRAME_TYPES.main) {
       parent = parent.parent;
     }
   }

--- a/src/main.ts
+++ b/src/main.ts
@@ -56,7 +56,7 @@ const dispatcher = async (action: {
 
     // retrieve existing options
     const lastUsedOptions: {
-      action: 'duplicate' | 'replace',
+      action: 'duplicate' | 'replace' | 'new-page',
       translateLocked: boolean,
       languages: Array<string>,
     } = await figma.clientStorage.getAsync(DATA_KEYS.options);
@@ -68,7 +68,7 @@ const dispatcher = async (action: {
       // set preliminary options
       const options: {
         languages: Array<string>,
-        action: 'duplicate' | 'replace',
+        action: 'duplicate' | 'replace' | 'new-page',
         translateLocked: boolean,
       } = {
         languages: [language],

--- a/src/views/webview.css
+++ b/src/views/webview.css
@@ -96,6 +96,10 @@ h3 {
   height: 32px;
 }
 
+.container .button.working {
+  opacity: 0.5;
+}
+
 /*
   boilerplate
   source: Tom Lowry's Figma UI JS/CSS files

--- a/src/views/webview.html
+++ b/src/views/webview.html
@@ -52,7 +52,6 @@
           name="text-action"
           value="new-page"
           id="text-new-page"
-          disabled
         >
         <label
           class="radio__label"


### PR DESCRIPTION
Enables the “Create page” on translate feature. Selected items are moved to a new page, and then translated. The original selection is left intact.